### PR TITLE
Add selection badge and improve FilterChip UX

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -72,7 +72,7 @@ function App() {
         
         <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
           <FilterChip
-            label="Filter default"
+            label="Parking slot"
             badgeCount={7}
             options={mockData}
             onSelectionChange={(selectedOptions) => {

--- a/src/components/FilterChip.js
+++ b/src/components/FilterChip.js
@@ -122,7 +122,6 @@ const FilterChip = ({
             {selectedCount > 0 && (
               <Box
                 sx={{
-                  ml: '8px',
                   display: 'inline-flex',
                   alignItems: 'center',
                   justifyContent: 'center',

--- a/src/components/FilterChip.js
+++ b/src/components/FilterChip.js
@@ -257,18 +257,7 @@ const FilterChip = ({
 
             {/* No Results */}
             {hasNoResults && (
-              <Typography
-                variant="body2"
-                sx={{
-                  color: 'text.secondary',
-                  fontSize: '13px',
-                  lineHeight: '18px',
-                  letterSpacing: '0.16px',
-                  mb: 1,
-                }}
-              >
-                No item selected
-              </Typography>
+              <NoItemSelected />
             )}
 
             {/* Selected Items Section */}

--- a/src/components/FilterChip.js
+++ b/src/components/FilterChip.js
@@ -24,7 +24,7 @@ import NoItemSelected from './NoItemSelected';
 const CloseFilled = (props) => <CloseIcon {...props} />;
 
 const FilterChip = ({
-  label = 'Filter default',
+  label = 'Parking slot',
   badgeCount = 0,
   options = [],
   onSelectionChange,

--- a/src/components/FilterChip.js
+++ b/src/components/FilterChip.js
@@ -36,6 +36,7 @@ const FilterChip = ({
     options.filter(option => option.checked)
   );
   const chipRef = useRef(null);
+  const [resetTriggered, setResetTriggered] = useState(false);
 
   const isOpen = Boolean(anchorEl);
   const selectedCount = selectedOptions.length;
@@ -47,18 +48,20 @@ const FilterChip = ({
   const handleClose = () => {
     setAnchorEl(null);
     setSearchValue('');
+    setResetTriggered(false);
   };
 
   const handleOptionToggle = (option) => {
+    setResetTriggered(false);
     const isSelected = selectedOptions.find(selected => selected.id === option.id);
     let newSelectedOptions;
-    
+
     if (isSelected) {
       newSelectedOptions = selectedOptions.filter(selected => selected.id !== option.id);
     } else {
       newSelectedOptions = [...selectedOptions, option];
     }
-    
+
     setSelectedOptions(newSelectedOptions);
     onSelectionChange?.(newSelectedOptions);
   };
@@ -72,10 +75,12 @@ const FilterChip = ({
   const handleReset = () => {
     setSelectedOptions([]);
     onSelectionChange?.([]);
+    setResetTriggered(true);
   };
 
   const handleSearchChange = (event) => {
     setSearchValue(event.target.value);
+    setResetTriggered(false);
   };
 
   const clearSearch = () => {
@@ -256,8 +261,21 @@ const FilterChip = ({
             />
 
             {/* No Results */}
-            {hasNoResults && (
+            {resetTriggered && selectedCount === 0 ? (
               <NoItemSelected />
+            ) : hasNoResults && (
+              <Typography
+                variant="body2"
+                sx={{
+                  color: 'text.secondary',
+                  fontSize: '13px',
+                  lineHeight: '18px',
+                  letterSpacing: '0.16px',
+                  mb: 1,
+                }}
+              >
+                No item selected
+              </Typography>
             )}
 
             {/* Selected Items Section */}

--- a/src/components/FilterChip.js
+++ b/src/components/FilterChip.js
@@ -19,6 +19,7 @@ import {
   Close as CloseIcon,
   Clear as ClearIcon,
 } from '@mui/icons-material';
+import NoItemSelected from './NoItemSelected';
 
 const CloseFilled = (props) => <CloseIcon {...props} />;
 

--- a/src/components/FilterChip.js
+++ b/src/components/FilterChip.js
@@ -177,7 +177,7 @@ const FilterChip = ({
           height: '32px',
           borderRadius: '100px',
           border: '1px solid',
-          borderColor: 'grey.300',
+          borderColor: isOpen ? 'primary.main' : 'grey.300',
           backgroundColor: 'grey.100',
           '& .MuiChip-label': {
             padding: '4px 4px',

--- a/src/components/FilterChip.js
+++ b/src/components/FilterChip.js
@@ -118,6 +118,30 @@ const FilterChip = ({
               {label}
             </Typography>
             <InfoIcon sx={{ fontSize: 24, color: 'rgb(95,95,95)', ml: '8px' }} />
+
+            {selectedCount > 0 && (
+              <Box
+                sx={{
+                  ml: '8px',
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  bgcolor: 'primary.main',
+                  color: 'primary.contrastText',
+                  fontSize: '12px',
+                  fontWeight: 500,
+                  lineHeight: '20px',
+                  minWidth: '20px',
+                  height: '20px',
+                  borderRadius: '100px',
+                  px: '6.5px',
+                }}
+                aria-hidden
+              >
+                {selectedCount}
+              </Box>
+            )}
+
             <Box sx={{ ml: 'auto', display: 'flex', alignItems: 'center' }}>
               <CloseFilled sx={{ fontSize: 24, color: 'rgb(95,95,95)' }} />
             </Box>

--- a/src/components/NoItemSelected.js
+++ b/src/components/NoItemSelected.js
@@ -6,13 +6,15 @@ const NoItemSelected = () => {
     <Box
       sx={{
         display: 'flex',
-        padding: '8px 16px',
-        alignItems: 'flex-start',
         alignContent: 'flex-start',
-        gap: '8px',
+        alignItems: 'flex-start',
         alignSelf: 'stretch',
         flexWrap: 'wrap',
+        fontWeight: '400',
+        gap: '8px',
         position: 'relative',
+        marginBottom: '8px',
+        padding: '8px 16px',
       }}
     >
       <Box

--- a/src/components/NoItemSelected.js
+++ b/src/components/NoItemSelected.js
@@ -37,14 +37,13 @@ const NoItemSelected = () => {
         >
           <Typography
             sx={{
-              color: '#5F5F5F',
-              fontFamily: 'Roboto, -apple-system, Roboto, Helvetica, sans-serif',
+              color: 'rgba(158,158,158,1)',
               fontSize: '13px',
-              fontStyle: 'normal',
               fontWeight: 400,
-              lineHeight: '18px',
               letterSpacing: '0.16px',
+              lineHeight: '18px',
               position: 'relative',
+              textDecoration: 'rgb(95, 95, 95)',
             }}
           >
             No item selected

--- a/src/components/NoItemSelected.js
+++ b/src/components/NoItemSelected.js
@@ -1,0 +1,56 @@
+import React from 'react';
+import { Box, Typography } from '@mui/material';
+
+const NoItemSelected = () => {
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        padding: '8px 16px',
+        alignItems: 'flex-start',
+        alignContent: 'flex-start',
+        gap: '8px',
+        alignSelf: 'stretch',
+        flexWrap: 'wrap',
+        position: 'relative',
+      }}
+    >
+      <Box
+        sx={{
+          display: 'flex',
+          width: '319px',
+          flexDirection: 'column',
+          alignItems: 'flex-start',
+          gap: '8px',
+          position: 'relative',
+        }}
+      >
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'flex-start',
+            position: 'relative',
+          }}
+        >
+          <Typography
+            sx={{
+              color: '#5F5F5F',
+              fontFamily: 'Roboto, -apple-system, Roboto, Helvetica, sans-serif',
+              fontSize: '13px',
+              fontStyle: 'normal',
+              fontWeight: 400,
+              lineHeight: '18px',
+              letterSpacing: '0.16px',
+              position: 'relative',
+            }}
+          >
+            No item selected
+          </Typography>
+        </Box>
+      </Box>
+    </Box>
+  );
+};
+
+export default NoItemSelected;


### PR DESCRIPTION
## Purpose

The user requested several UX improvements to the FilterChip component to enhance the filtering experience:
- Add a visual indicator showing the number of selected items without opening the popup
- Change the filter label from generic "Filter default" to more specific "Parking slot"
- Provide visual feedback when the popup is open through border color changes
- Show a "No item selected" state when the reset function is triggered

## Code changes

- **Added selection count badge**: Displays a blue badge with the number of selected items between the info and close icons
- **Updated filter label**: Changed default label from "Filter default" to "Parking slot" in both App.js and FilterChip.js
- **Enhanced border styling**: FilterChip border now changes to primary blue (#2196F3) when popup is open
- **Added NoItemSelected component**: New component that displays "No item selected" message when reset is triggered
- **Improved state management**: Added `resetTriggered` state to properly handle the reset functionality and show appropriate UI statesTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/4f7044d2448a418baf71d1e9af803ee1/flare-landing)

👀 [Preview Link](https://4f7044d2448a418baf71d1e9af803ee1-flare-landing.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>4f7044d2448a418baf71d1e9af803ee1</projectId>-->
<!--<branchName>flare-landing</branchName>-->